### PR TITLE
Pipeline script edits

### DIFF
--- a/nastybugs.sh
+++ b/nastybugs.sh
@@ -7,7 +7,8 @@ if [ "$#" -ne 6 ]; then
 	exit 1
 fi
 
-sraid= $(readlink -f "$1")
+sraid=$(readlink -f "$1") 
+###JD:removed space after = in sraid assignment
 hostGen=$(readlink -f "$2")
 cardgene=$(readlink -f "$3")
 cardsnp=$(readlink -f "$4")
@@ -16,25 +17,36 @@ outdir=$(readlink -f "$6")
 
 ## Getting host genome from NCBI and create BLAST db 
 
-printf "Getting host genome and create BLAST databases\n"
-date
-mkdir $hostGen
-wget -P $hostGen ftp://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/annotation/GRCh37_latest/refseq_identifiers/GRCh37_latest_genomic.fna.gz
-gunzip $hostGen/GRCh37_latest_genomic.fna.gz
-makeblastdb -in $hostGen/GRCh37_latest_genomic.fna -dbtype nucl -out $hostGen/hg19
+###JD:added if statement to check whether database has already been downloaded 
+if [ ! -e "$hostGen/GRCh37_latest_genomic.fna" ]; then
+  printf "Getting host genome and create BLAST databases\n"
+  date
+  mkdir $hostGen
+  wget -P $hostGen ftp://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/annotation/GRCh37_latest/refseq_identifiers/GRCh37_latest_genomic.fna.gz
+  gunzip -v $hostGen/GRCh37_latest_genomic.fna.gz
+  makeblastdb -in $hostGen/GRCh37_latest_genomic.fna -dbtype nucl -out $hostGen/hg19
+fi
 
 ## Getting CARD Gene and SNP databases and create BLAST db
 ## https://card.mcmaster.ca/download
-printf "Getting CARD databases\n"
-date
-mkdir $cardgene $cardsnp
-wget -P $cardgene https://card.mcmaster.ca/download/0/broadstreet-v2.0.0.tar.gz
-tar xvf $cardgene/broadstreet-v2.0.0.tar.gz -C $cardgene/
-makeblastdb -in $cardgene/nucleotide_fasta_protein_homolog_model.fasta -dbtype nucl -out $cardgene/cardgenedb
-cp $cardgene/nucleotide_fasta_protein_variant_model.fasta $cardsnp/.
-makeblastdb -in $cardsnp/nucleotide_fasta_protein_variant_model.fasta -dbtype nucl -out $cardsnp/cardsnpdb
+###JD:added if statement to check card db already exists
+if [ ! -e "$cardgene/cardgenedb.nhr" ]; then
+  printf "Getting CARD databases\n"
+  date
+  mkdir $cardgene $cardsnp
+  ###JD:had to add --no-check-certificate in order to download - not sure if this is a good solution
+  wget --no-check-certificate -O $cardgene/broadstreet.tar.gz https://card.mcmaster.ca/latest/data
+  ###JD:changed download location to latest rather than specific version
+  tar xvf $cardgene/broadstreet.tar.gz -C $cardgene/
+  makeblastdb -in $cardgene/nucleotide_fasta_protein_homolog_model.fasta -dbtype nucl -out $cardgene/cardgenedb
+  cp $cardgene/nucleotide_fasta_protein_variant_model.fasta $cardsnp/.
+  makeblastdb -in $cardsnp/nucleotide_fasta_protein_variant_model.fasta -dbtype nucl -out $cardsnp/cardsnpdb
+fi
 
 mkdir $outdir
+
+###JD:added prompt notification for user peace of mind
+printf "\n\nprocessing reads..."
 
 for sra in $(cat "$1"); do
 
@@ -68,14 +80,16 @@ for sra in $(cat "$1"); do
     magicblast -num_threads $cores  -infmt fasta -query $outdir/${sra}_unmapped_read_one_trimmed -query_mate $outdir/${sra}_unmapped_read_two_trimmed -score 50 -penalty -3 -out $outdir/$sra.CARD_gene.sam -db $cardgene/cardgenedb
     magicblast -num_threads $cores  -infmt fasta -query $outdir/${sra}_unmapped_read_one_trimmed -query_mate $outdir/${sra}_unmapped_read_two_trimmed -score 50 -penalty -3 -out $outdir/$sra.CARD_snp.sam -db $cardsnp/cardsnpdb
 
-  elif [[ (-s $read1_count) ]]; then
+  ###JD:in my unpaired run, reads were coming out in read_zero, changed if statement to check in this file rather than read_one, and also clipper and magicblast to read the _zero file
+  elif [[ (-s $read0_count) ]]; then
     printf "Single End - %d %d %d\n" "$read1_count" "$read2_count" "$read0_count"
     date
-    fastx_clipper -i $outdir/${sra}_unmapped_read_one -o $outdir/${sra}_unmapped_read_one_trimmed
+    fastx_clipper -i $outdir/${sra}_unmapped_read_zero -o $outdir/${sra}_unmapped_read_zero_trimmed
     # Run magicblast using CARD Gene Homology nucleotide_fasta_protein_homolog_model.fasta 
-    magicblast -num_threads $cores -infmt fasta -query $outdir/${sra}_unmapped_read_one_trimmed -score 50 -penalty -3 -out $outdir/$sra.CARD_gene.sam -db $cardgene/cardgenedb
+    magicblast -num_threads $cores -infmt fasta -query $outdir/${sra}_unmapped_read_zero_trimmed -score 50 -penalty -3 -out $outdir/$sra.CARD_gene.sam -db $cardgene/cardgenedb
     # Run magicblast using CARD variant  - nucleotide_fasta_protein_variant_model.fasta
-    magicblast -num_threads $cores -infmt fasta -query $outdir/${sra}_unmapped_read_one_trimmed -score 50 -penalty -3 -out $outdir/$sra.CARD_snp.sam -db $cardgene/cardsnpdb 
+    ###JD:corrected cardsnpdb location to $cardsnp/
+    magicblast -num_threads $cores -infmt fasta -query $outdir/${sra}_unmapped_read_zero_trimmed -score 50 -penalty -3 -out $outdir/$sra.CARD_snp.sam -db $cardsnp/cardsnpdb 
   else 
     printf "ERROR: no reads to align to CARD databases\n"
   fi

--- a/nastybugs.sh
+++ b/nastybugs.sh
@@ -46,7 +46,7 @@ fi
 mkdir $outdir
 
 ###JD:added prompt notification for user peace of mind
-printf "\n\nprocessing reads..."
+printf "\nprocessing reads...\n"
 
 for sra in $(cat "$1"); do
 
@@ -81,7 +81,7 @@ for sra in $(cat "$1"); do
     magicblast -num_threads $cores  -infmt fasta -query $outdir/${sra}_unmapped_read_one_trimmed -query_mate $outdir/${sra}_unmapped_read_two_trimmed -score 50 -penalty -3 -out $outdir/$sra.CARD_snp.sam -db $cardsnp/cardsnpdb
 
   ###JD:in my unpaired run, reads were coming out in read_zero, changed if statement to check in this file rather than read_one, and also clipper and magicblast to read the _zero file
-  elif [[ (-s $read0_count) ]]; then
+  elif [[ ( $read0_count > 0 ) ]]; then
     printf "Single End - %d %d %d\n" "$read1_count" "$read2_count" "$read0_count"
     date
     fastx_clipper -i $outdir/${sra}_unmapped_read_zero -o $outdir/${sra}_unmapped_read_zero_trimmed
@@ -105,4 +105,3 @@ for sra in $(cat "$1"); do
   date
   printf "\n"
 done > log
-


### PR DESCRIPTION
I had three major errors that stopped the pipeline when testing with SRR5548989 (singletons from merged PE reads) -

1. Download of card db failed due to error (line 31) -
  ERROR: cannot verify card.mcmaster.ca's certificate, issued by ‘/C=GB/ST=Greater Manchester/L=Salford/O=COMODO CA Limited/CN=COMODO RSA Organization Validation Secure Server CA’:
  Unable to locally verify the issuer's authority.
  To connect to card.mcmaster.ca insecurely, use `--no-check-certificate'.
This was reproducible on 2 different linux machines as well as biowulf, so think it is really to do with the card certificates rather than the local machine. I fixed with the --no-check-certificate as suggested but I don't know if that is a secure long-term solution.

2. When checking for the existence of unpaired reads (line 71), checking against $read1_count was failing, because my singletons were being written out to ${sra}_unmapped_read_zero. I edited to use the _zero file instead.

3. There was a typo in the -db database location for cardsnp (line 78), which I corrected.


I made a couple of tweaks to streamline the script during testing -

- When running the script multiple times, it always downloads the databases each time, even if they already exist. I added an if statement to check for the existence of the databases before download.

- There was a warning coming up from line 10, where there was a typo on the assignment of $sraid, which I fixed. Also, it doesn't appear that $sraid is ever actually used by the script.

- When the magicblasts start running at line 39 the prompt looks empty, and stays that way for a long time. That made me nervous about a crash, so I added a message to the user to reassure them that the reads are processing.

- I changed the location of the card db download (line 31) to be the latest version, rather than a specific version that may go out of date.